### PR TITLE
GraphQL part 2

### DIFF
--- a/books_server/src/index.js
+++ b/books_server/src/index.js
@@ -109,7 +109,7 @@ knex('users')
         })
 
         const { url } = await startStandaloneServer(server, {
-            listen: { port: 4001 },
+            listen: { port: 4009 },
             context: async () => {
                 const { cache } = server
 

--- a/books_server/src/index.js
+++ b/books_server/src/index.js
@@ -1,5 +1,8 @@
 const { ApolloServer } = require('@apollo/server');
 const { startStandaloneServer } = require('@apollo/server/standalone');
+const DataLoader = require('dataloader');
+
+const USE_DATA_LOADER_TO_RESOLVE_N_PLUS_1 = true
 
 const gql = require('graphql-tag')
 const { faker } = require('@faker-js/faker');
@@ -38,7 +41,11 @@ const typeDefs = gql`
 
 const resolvers = {
     Book: {
-        author: async parent => {
+        author: async (parent, _, ctx) => {
+            if (USE_DATA_LOADER_TO_RESOLVE_N_PLUS_1) {
+                return ctx.authorLoader.load(parent.authorId)
+            }
+
             const author = await knex("users")
                 .select()
                 .where("id", parent.authorId)
@@ -50,7 +57,7 @@ const resolvers = {
     Query: {
         // books: async () => {
         books: async (parent, args, contextValue, info) => {
-            console.log({ parent, args, contextValue, info })
+            // console.log({ parent, args, contextValue, info })
 
             const books = await knex("books")
                 .select()
@@ -119,7 +126,25 @@ knex('users')
                     // passing in our server's cache
                     dataSources: {
                         moviesAPI: new MoviesAPI({ cache })
-                    }
+                    },
+                    // --- use DataLoader to resolve n+1 problem ---
+                    // not used if !USE_DATA_LOADER_TO_RESOLVE_N_PLUS_1
+                    authorLoader: new DataLoader(async keys => {
+                        // keys are all the Book authorId
+                        // console.log("DataLoader keys: ", keys)
+        
+                        const authors = await knex('users')
+                            .select()
+                            .whereIn("id", keys)
+        
+                        const authorMap = {}
+                        authors.forEach(author => {
+                            authorMap[author.id] = author
+                        })
+        
+                        return keys.map(key => authorMap[key])
+                    })
+                    // ---------------------------------------------
                 }
             }
         })

--- a/books_server/src/index.js
+++ b/books_server/src/index.js
@@ -111,6 +111,7 @@ knex('users')
         const { url } = await startStandaloneServer(server, {
             listen: { port: 4009 },
             context: async () => {
+                // use default InMemoryLRUCache
                 const { cache } = server
 
                 return {

--- a/books_server/src/movies-api.js
+++ b/books_server/src/movies-api.js
@@ -4,6 +4,12 @@ class MoviesAPI extends RESTDataSource {
     baseURL = 'https://www.omdbapi.com/?apikey=5ca5c38a'
     // t=iron+man
 
+    constructor(options) {
+        // this sends our server's `cache` through
+        // see https://www.apollographql.com/docs/apollo-server/data/fetching-rest#caching
+        super(options)
+    }
+
     async getMovie(id) {
         return this.get(`${this.baseURL}&i=${id}`)
     }


### PR DESCRIPTION
- use default in memory cache
- use DataLoader to resolve n+1 problem on books-authors query